### PR TITLE
Mark all modules explicitly as Safe

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,7 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.11.20201212
+# version: 0.11.20201223
+#
+# REGENDATA ("0.11.20201223",["--config=cabal.haskell-ci","github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -20,25 +22,38 @@ on:
       - master
 jobs:
   linux:
-    name: Haskell-CI Linux
+    name: Haskell-CI Linux - GHC ${{ matrix.ghc }}
     runs-on: ubuntu-18.04
     container:
       image: buildpack-deps:bionic
+    continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
           - ghc: 8.10.2
+            allow-failure: false
           - ghc: 8.8.4
+            allow-failure: false
           - ghc: 8.6.5
+            allow-failure: false
           - ghc: 8.4.4
+            allow-failure: false
           - ghc: 8.2.2
+            allow-failure: false
           - ghc: 8.0.2
+            allow-failure: false
           - ghc: 7.10.3
+            allow-failure: false
           - ghc: 7.8.4
+            allow-failure: false
           - ghc: 7.6.3
+            allow-failure: false
           - ghc: 7.4.2
+            allow-failure: false
           - ghc: 7.2.2
+            allow-failure: false
           - ghc: 7.0.4
+            allow-failure: false
       fail-fast: false
     steps:
       - name: apt
@@ -150,16 +165,15 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.ghc }}-${{ github.sha }}
           path: ~/.cabal/store
           restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
-      - name: install dependencies
-        run: |
-          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only all
-          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dependencies-only all
       - name: build w/o tests
         run: |
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
       - name: build
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all
+      - name: tests
+        run: |
+          if [ $((HCNUMVER >= 70400)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct ; fi
       - name: cabal check
         run: |
           cd ${PKGDIR_indexed_traversable} || false

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,2 +1,3 @@
-branches:       master
-jobs-selection: any
+branches:             master
+install-dependencies: False
+jobs-selection:       any

--- a/indexed-traversable-instances/indexed-traversable-instances.cabal
+++ b/indexed-traversable-instances/indexed-traversable-instances.cabal
@@ -50,6 +50,17 @@ library
 
   exposed-modules:  Data.Functor.WithIndex.Instances
 
+test-suite safe
+  type:             exitcode-stdio-1.0
+  default-language: Haskell2010
+  ghc-options:      -Wall
+  hs-source-dirs:   tests
+  main-is:          safe.hs
+  build-depends:
+      base
+    , indexed-traversable
+    , indexed-traversable-instances
+
 test-suite indexed-tests
   type:             exitcode-stdio-1.0
   default-language: Haskell2010

--- a/indexed-traversable-instances/tests/safe.hs
+++ b/indexed-traversable-instances/tests/safe.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE Safe #-}
+module Main (main) where
+
+import Data.Functor.WithIndex ()
+import Data.Functor.WithIndex.Instances ()
+import Data.Foldable.WithIndex ()
+import Data.Traversable.WithIndex ()
+
+main :: IO ()
+main = return ()

--- a/indexed-traversable/Changelog.md
+++ b/indexed-traversable/Changelog.md
@@ -1,3 +1,8 @@
+# 0.1.1 [2020-12-27]
+
+- Mark all modules as `Safe`.
+  See https://gitlab.haskell.org/ghc/ghc/-/issues/19127
+
 # 0.1 [2020-12-15]
 
 - Split out and combine this package functionality from `lens` and `optics`

--- a/indexed-traversable/indexed-traversable.cabal
+++ b/indexed-traversable/indexed-traversable.cabal
@@ -1,6 +1,6 @@
 cabal-version:      1.12
 name:               indexed-traversable
-version:            0.1
+version:            0.1.1
 build-type:         Simple
 license:            BSD2
 license-file:       LICENSE
@@ -56,7 +56,10 @@ library
   default-language: Haskell2010
   ghc-options:      -Wall
   hs-source-dirs:   src
-  other-modules:    WithIndex
+  other-modules:
+    GhcExts
+    WithIndex
+
   exposed-modules:
     Data.Foldable.WithIndex
     Data.Functor.WithIndex

--- a/indexed-traversable/src/Data/Foldable/WithIndex.hs
+++ b/indexed-traversable/src/Data/Foldable/WithIndex.hs
@@ -1,3 +1,9 @@
+{-# LANGUAGE CPP         #-}
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Safe        #-}
+#elif __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
 -- | Indexed Foldables.
 module Data.Foldable.WithIndex (
     -- * Indexed Foldables
@@ -24,8 +30,8 @@ import Control.Applicative (Applicative (..))
 import Control.Monad       (liftM, void)
 import Data.Foldable       (Foldable, any)
 import Data.Monoid         (All (..), Any (..))
-import GHC.Exts            (build)
 
+import GhcExts (build)
 import WithIndex
 
 -- | Return whether or not any element in a container satisfies a predicate, with access to the index @i@.

--- a/indexed-traversable/src/Data/Functor/WithIndex.hs
+++ b/indexed-traversable/src/Data/Functor/WithIndex.hs
@@ -1,3 +1,9 @@
+{-# LANGUAGE CPP         #-}
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Safe        #-}
+#elif __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
 module Data.Functor.WithIndex (
     -- * Indexed Functors
     FunctorWithIndex(..),

--- a/indexed-traversable/src/Data/Traversable/WithIndex.hs
+++ b/indexed-traversable/src/Data/Traversable/WithIndex.hs
@@ -1,3 +1,9 @@
+{-# LANGUAGE CPP         #-}
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Safe        #-}
+#elif __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
 -- | Indexed Traversables
 module Data.Traversable.WithIndex (
     -- * Indexed Traversables

--- a/indexed-traversable/src/GhcExts.hs
+++ b/indexed-traversable/src/GhcExts.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE CPP         #-}
+#if __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
+module GhcExts (
+    build,
+) where
+
+import GHC.Exts (build)


### PR DESCRIPTION
Add an internal module marking `build` as Trustworthy
https://gitlab.haskell.org/ghc/ghc/-/issues/19127