### PR TITLE
switched references to lens 'Of'- functions to base functions.

### DIFF
--- a/indexed-traversable/src/Data/Foldable/WithIndex.hs
+++ b/indexed-traversable/src/Data/Foldable/WithIndex.hs
@@ -122,10 +122,10 @@ imapM_ f = liftM skip . getSequenced #. ifoldMap (\i -> Sequenced #. f i)
 -- 'iforM_' ≡ 'flip' 'imapM_'
 -- @
 --
--- When you don't need access to the index then 'Control.Lens.Fold.forMOf_' is more flexible in what it accepts.
+-- When you don't need access to the index then 'Control.Monad.forM_' is more flexible in what it accepts.
 --
 -- @
--- 'Control.Lens.Fold.forMOf_' l a ≡ 'iforMOf' l a '.' 'const'
+-- 'Control.Monad.forM_' a ≡ 'iforM' a '.' 'const'
 -- @
 iforM_ :: (FoldableWithIndex i t, Monad m) => t a -> (i -> a -> m b) -> m ()
 iforM_ = flip imapM_

--- a/indexed-traversable/src/Data/Traversable/WithIndex.hs
+++ b/indexed-traversable/src/Data/Traversable/WithIndex.hs
@@ -66,10 +66,10 @@ iforM = flip imapM
 
 -- | Generalizes 'Data.Traversable.mapAccumR' to add access to the index.
 --
--- 'imapAccumROf' accumulates state from right to left.
+-- 'imapAccumR' accumulates state from right to left.
 --
 -- @
--- 'Control.Lens.Traversal.mapAccumR' ≡ 'imapAccumR' '.' 'const'
+-- 'Data.Traversable.mapAccumR' ≡ 'imapAccumR' '.' 'const'
 -- @
 imapAccumR :: TraversableWithIndex i t => (i -> s -> a -> (s, b)) -> s -> t a -> (s, t b)
 imapAccumR f s0 a = swap (Lazy.runState (forwards (itraverse (\i c -> Backwards (Lazy.state (\s -> swap (f i s c)))) a)) s0)
@@ -77,10 +77,10 @@ imapAccumR f s0 a = swap (Lazy.runState (forwards (itraverse (\i c -> Backwards 
 
 -- | Generalizes 'Data.Traversable.mapAccumL' to add access to the index.
 --
--- 'imapAccumLOf' accumulates state from left to right.
+-- 'imapAccumL' accumulates state from left to right.
 --
 -- @
--- 'Control.Lens.Traversal.mapAccumLOf' ≡ 'imapAccumL' '.' 'const'
+-- 'Data.Traversable.mapAccumL' ≡ 'imapAccumL' '.' 'const'
 -- @
 imapAccumL :: TraversableWithIndex i t => (i -> s -> a -> (s, b)) -> s -> t a -> (s, t b)
 imapAccumL f s0 a = swap (Lazy.runState (itraverse (\i c -> Lazy.state (\s -> swap (f i s c))) a) s0)

--- a/indexed-traversable/src/WithIndex.hs
+++ b/indexed-traversable/src/WithIndex.hs
@@ -120,6 +120,12 @@ class Foldable f => FoldableWithIndex i f | f -> i where
 #endif
 
   -- | A variant of 'ifoldMap' that is strict in the accumulator.
+  --
+  -- When you don't need access to the index then 'Data.Foldable.foldMap'' is more flexible in what it accepts.
+  --
+  -- @
+  -- 'foldMap'' ≡ 'ifoldMap'' '.' 'const'
+  -- @
   ifoldMap' :: Monoid m => (i -> a -> m) -> f a -> m
   ifoldMap' f = ifoldl' (\i acc a -> mappend acc (f i a)) mempty
   {-# INLINE ifoldMap' #-}
@@ -163,7 +169,7 @@ class Foldable f => FoldableWithIndex i f | f -> i where
   -- When you don't need access to the index then 'Control.Lens.Fold.foldlOf'' is more flexible in what it accepts.
   --
   -- @
-  -- 'Control.Lens.Fold.foldlOf'' l ≡ 'ifoldlOf'' l '.' 'const'
+  -- 'Data.Foldable.foldl'' l ≡ 'ifoldl'' l '.' 'const'
   -- @
   ifoldl' :: (i -> b -> a -> b) -> b -> f a -> b
   ifoldl' f z0 xs = ifoldr f' id xs z0


### PR DESCRIPTION
There are still a few references to when indexed-traversable was part of lens. This changes references to lens's 'Of' functions to the standard equivalents in Data.Foldable.

I also added a mention of `foldMap'`, since that's a thing now.