### PR TITLE
bump base upper bound to <4.18

### DIFF
--- a/indexed-traversable-instances/indexed-traversable-instances.cabal
+++ b/indexed-traversable-instances/indexed-traversable-instances.cabal
@@ -45,7 +45,7 @@ library
   ghc-options:      -Wall
   hs-source-dirs:   src
   build-depends:
-      base                  >=4.5      && <4.17
+      base                  >=4.5      && <4.18
     , indexed-traversable   >=0.1      && <0.2
     , OneTuple              >=0.3      && <0.4
     , tagged                >=0.8.6    && <0.9

--- a/indexed-traversable/indexed-traversable.cabal
+++ b/indexed-traversable/indexed-traversable.cabal
@@ -70,7 +70,7 @@ library
 
   build-depends:
       array         >=0.3.0.2 && <0.6
-    , base          >=4.3     && <4.17
+    , base          >=4.3     && <4.18
     , containers    >=0.4.0.0 && <0.7
     , transformers  >=0.3.0.0 && <0.7
 


### PR DESCRIPTION
This builds with

```
cabal build all --disable-benchmarks --disable-tests -w ghc-9.4.1 --allow-newer='hashable:*,OneTuple:*'
```