### PR TITLE
Make it compile with MicroHs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist-newstyle
+dist-mcabal

--- a/indexed-traversable/indexed-traversable.cabal
+++ b/indexed-traversable/indexed-traversable.cabal
@@ -71,5 +71,5 @@ library
     , containers    >=0.6.0.1 && <0.8
     , transformers  >=0.5.6.0 && <0.7
 
-  if !impl(ghc >=9.6)
+  if !impl(ghc >=9.6) && !impl(mhs)
     build-depends: foldable1-classes-compat >=0.1 && <0.2

--- a/indexed-traversable/src/GhcList.hs
+++ b/indexed-traversable/src/GhcList.hs
@@ -1,15 +1,24 @@
 {-# LANGUAGE CPP         #-}
+#ifdef __GLASGOW_HASKELL__
 #if MIN_VERSION_base(4,17,0)
 {-# LANGUAGE Safe #-}
 #elif __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif
+#else
+{-# LANGUAGE RankNTypes #-}
+#endif
 module GhcList (
     build,
 ) where
 
+#ifdef __GLASGOW_HASKELL__
 #if MIN_VERSION_base(4,17,0)
 import GHC.List (build)
 #else
 import GHC.Exts (build)
+#endif
+#else
+build :: (forall b. (a -> b -> b) -> b -> b) -> [a]
+build g = g (:) []
 #endif

--- a/indexed-traversable/src/WithIndex.hs
+++ b/indexed-traversable/src/WithIndex.hs
@@ -41,9 +41,11 @@ import Data.Traversable              (Traversable (..))
 import Data.Tree                     (Tree (..))
 import Data.Void                     (Void)
 
+#ifdef __GLASGOW_HASKELL__
 import GHC.Generics
        (K1 (..), Par1 (..), Rec1 (..), U1 (..), V1, (:*:) (..), (:+:) (..),
        (:.:) (..))
+#endif
 
 import qualified Data.Array    as Array
 import qualified Data.IntMap   as IntMap
@@ -276,6 +278,7 @@ instance FunctorWithIndex k ((,) k) where
   imap f (k,a) = (k, f k a)
   {-# INLINE imap #-}
 
+#ifdef __GLASGOW_HASKELL__
 instance FoldableWithIndex k ((,) k) where
   ifoldMap = uncurry'
   {-# INLINE ifoldMap #-}
@@ -283,6 +286,7 @@ instance FoldableWithIndex k ((,) k) where
 instance TraversableWithIndex k ((,) k) where
   itraverse f (k, a) = (,) k <$> f k a
   {-# INLINE itraverse #-}
+#endif
 
 -- | The position in the list is available as the index.
 instance FunctorWithIndex Int [] where
@@ -559,6 +563,7 @@ instance TraversableWithIndex k (Map k) where
   itraverse = Map.traverseWithKey
   {-# INLINE itraverse #-}
 
+#ifdef __GLASGOW_HASKELL__
 -------------------------------------------------------------------------------
 -- GHC.Generics
 -------------------------------------------------------------------------------
@@ -659,6 +664,7 @@ instance FoldableWithIndex Void (K1 i c) where
 instance TraversableWithIndex Void (K1 i c) where
   itraverse _ (K1 a) = pure (K1 a)
   {-# INLINE itraverse #-}
+#endif
 
 -------------------------------------------------------------------------------
 -- Misc.


### PR DESCRIPTION
MicroHs currently doesn't support `Generic`s and it doesn't have `Foldable` & `Traversable` instances for tuples, so the parts needing those are guarded with `#ifdef __GLASGOW_HASKELL__`.