### PR TITLE
Switch to tasty-bench and add more benchmarks

### DIFF
--- a/indexed-traversable-benchmarks/bench/folds.hs
+++ b/indexed-traversable-benchmarks/bench/folds.hs
@@ -3,7 +3,8 @@
 {-# LANGUAGE RankNTypes       #-}
 module Main (main) where
 
-import Criterion.Main (bench, bgroup, defaultMain, nf)
+import Data.Monoid      (Sum(..))
+import Test.Tasty.Bench (bench, bgroup, defaultMain, nf)
 
 import qualified Data.Foldable     as F
 import qualified Data.HashMap.Lazy as HM
@@ -21,30 +22,65 @@ main = defaultMain
       [ bench "native"     $ nf (V.toList . V.indexed) v
       , bench "itoList"    $ nf itoList v
       ]
+    , bench "ifoldMap ([])"     $ nf (ifoldMap (\i n -> [(i, n)])) v
+    , bench "ifoldMap (vector)" $ nf (ifoldMap (\i n -> V.singleton (i, n))) v
+    , bench "ifoldMap' (sum)"   $ nf (ifoldMap' (\i n -> Sum $ i + n)) v
+    , bench "ifoldr"            $ nf (ifoldr (\i n acc -> (i, n) : acc) []) v
+    , bench "ifoldl"            $ nf (ifoldl (\i acc n -> (i, n) : acc) []) v
+    , bench "ifoldr'"           $ nf (ifoldr' (\i n acc -> i + n + acc) 0) v
+    , bench "ifoldl'"           $ nf (ifoldl' (\i n acc -> i + n + acc) 0) v
     ]
   , bgroup "sequence"
     [ bgroup "itoList"
       [ bench "native"     $ nf (F.toList . Seq.mapWithIndex (,)) s
       , bench "itoList"    $ nf itoList s
       ]
+    , bench "ifoldMap ([])"     $ nf (ifoldMap (\i n -> [(i, n)])) s
+    , bench "ifoldMap (vector)" $ nf (ifoldMap (\i n -> V.singleton (i, n))) s
+    , bench "ifoldMap' (sum)"   $ nf (ifoldMap' (\i n -> Sum $ i + n)) s
+    , bench "ifoldr"            $ nf (ifoldr (\i n acc -> (i, n) : acc) []) s
+    , bench "ifoldl"            $ nf (ifoldl (\i acc n -> (i, n) : acc) []) s
+    , bench "ifoldr'"           $ nf (ifoldr' (\i n acc -> i + n + acc) 0) s
+    , bench "ifoldl'"           $ nf (ifoldl' (\i n acc -> i + n + acc) 0) s
     ]
   , bgroup "list"
     [ bgroup "itoList"
       [ bench "native"     $ nf (zip [(0::Int)..]) l
       , bench "itoList"    $ nf itoList l
       ]
+    , bench "ifoldMap ([])"     $ nf (ifoldMap (\i n -> [(i, n)])) l
+    , bench "ifoldMap (vector)" $ nf (ifoldMap (\i n -> V.singleton (i, n))) l
+    , bench "ifoldMap' (sum)"   $ nf (ifoldMap' (\i n -> Sum $ i + n)) l
+    , bench "ifoldr"            $ nf (ifoldr (\i n acc -> (i, n) : acc) []) l
+    , bench "ifoldl"            $ nf (ifoldl (\i acc n -> (i, n) : acc) []) l
+    , bench "ifoldr'"           $ nf (ifoldr' (\i n acc -> i + n + acc) 0) l
+    , bench "ifoldl'"           $ nf (ifoldl' (\i n acc -> i + n + acc) 0) l
     ]
   , bgroup "map"
     [  bgroup "itoList"
       [ bench "native"     $ nf Map.toList m
       , bench "itoList"    $ nf itoList m
       ]
+    , bench "ifoldMap ([])"     $ nf (ifoldMap (\i n -> [(i, n)])) m
+    , bench "ifoldMap (vector)" $ nf (ifoldMap (\i n -> V.singleton (i, n))) m
+    , bench "ifoldMap' (sum)"   $ nf (ifoldMap' (\i n -> Sum $ i + n)) m
+    , bench "ifoldr"            $ nf (ifoldr (\i n acc -> (i, n) : acc) []) m
+    , bench "ifoldl"            $ nf (ifoldl (\i acc n -> (i, n) : acc) []) m
+    , bench "ifoldr'"           $ nf (ifoldr' (\i n acc -> i + n + acc) 0) m
+    , bench "ifoldl'"           $ nf (ifoldl' (\i n acc -> i + n + acc) 0) m
     ]
   , bgroup "hashmap"
     [ bgroup "itoList"
       [ bench "native"     $ nf HM.toList h
       , bench "itoList"    $ nf itoList h
       ]
+    , bench "ifoldMap ([])"     $ nf (ifoldMap (\i n -> [(i, n)])) h
+    , bench "ifoldMap (vector)" $ nf (ifoldMap (\i n -> V.singleton (i, n))) h
+    , bench "ifoldMap' (sum)"   $ nf (ifoldMap' (\i n -> Sum $ i + n)) h
+    , bench "ifoldr"            $ nf (ifoldr (\i n acc -> (i, n) : acc) []) h
+    , bench "ifoldl"            $ nf (ifoldl (\i acc n -> (i, n) : acc) []) h
+    , bench "ifoldr'"           $ nf (ifoldr' (\i n acc -> i + n + acc) 0) h
+    , bench "ifoldl'"           $ nf (ifoldl' (\i n acc -> i + n + acc) 0) h
     ]
   ]
 

--- a/indexed-traversable-benchmarks/bench/traversals.hs
+++ b/indexed-traversable-benchmarks/bench/traversals.hs
@@ -4,7 +4,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Main (main) where
 
-import Criterion.Main (bench, bgroup, defaultMain, nf)
+import Test.Tasty.Bench (bench, bgroup, defaultMain, nf, nfAppIO)
 
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.Map          as Map
@@ -13,7 +13,7 @@ import qualified Data.Vector       as V
 
 import Data.Functor.WithIndex           (imap)
 import Data.Functor.WithIndex.Instances ()
-import Data.Traversable.WithIndex       (imapDefault)
+import Data.Traversable.WithIndex       (imapDefault, itraverse)
 
 main :: IO ()
 main = defaultMain
@@ -23,6 +23,7 @@ main = defaultMain
       , bench "imap"     $ nf (imap             (\i x -> x + i + 100)) v
       , bench "default"  $ nf (imapDefault      (\i x -> x + i + 100)) v
       ]
+    , bench "itraverse"  $ nfAppIO (itraverse (\i n -> pure (i, n)))   v
     ]
   , bgroup "sequence"
     [  bgroup "imap"
@@ -30,6 +31,7 @@ main = defaultMain
       , bench "imap"     $ nf (imap             (\i x -> x + i + 100)) s
       , bench "default"  $ nf (imapDefault      (\i x -> x + i + 100)) s
       ]
+    , bench "itraverse"  $ nfAppIO (itraverse (\i n -> pure (i, n)))   s
     ]
   , bgroup "list"
     [ bgroup "imap"
@@ -37,6 +39,7 @@ main = defaultMain
       , bench "imap"     $ nf (imap             (\i x -> x + i + 100))       l
       , bench "default"  $ nf (imapDefault      (\i x -> x + i + 100))       l
       ]
+    , bench "itraverse"  $ nfAppIO (itraverse (\i n -> pure (i, n)))         l
     ]
   , bgroup "map"
     [ bgroup "imap"
@@ -44,6 +47,7 @@ main = defaultMain
       , bench "imap"     $ nf (imap             (\i x -> x + i + 100)) m
       , bench "default"  $ nf (imapDefault      (\i x -> x + i + 100)) m
       ]
+    , bench "itraverse"  $ nfAppIO (itraverse (\i n -> pure (i, n)))   m
     ]
   , bgroup "hashmap"
     [ bgroup "imap"
@@ -51,6 +55,7 @@ main = defaultMain
       , bench "imap"     $ nf (imap             (\i x -> x + i + 100)) h
       , bench "default"  $ nf (imapDefault      (\i x -> x + i + 100)) h
       ]
+    , bench "itraverse"  $ nfAppIO (itraverse (\i n -> pure (i, n)))   h
     ]
   ]
 

--- a/indexed-traversable-benchmarks/indexed-traversable-benchmarks.cabal
+++ b/indexed-traversable-benchmarks/indexed-traversable-benchmarks.cabal
@@ -44,7 +44,7 @@ benchmark folds
     , unordered-containers
     , vector
 
-  build-depends:    criterion >=1.5.9.0 && <1.7
+  build-depends:    tasty-bench
 
 benchmark traversals
   type:             exitcode-stdio-1.0
@@ -60,4 +60,4 @@ benchmark traversals
     , unordered-containers
     , vector
 
-  build-depends:    criterion >=1.5.9.0 && <1.7
+  build-depends:    tasty-bench


### PR DESCRIPTION
It has less dependencies, runs faster and has --baseline option for comparing data between runs, which is very useful for comparing performance between code changes or GHC version changes.