### PR TITLE
Make functions for lists optimizer-friendly

### DIFF
--- a/indexed-traversable/src/WithIndex.hs
+++ b/indexed-traversable/src/WithIndex.hs
@@ -286,9 +286,7 @@ instance TraversableWithIndex k ((,) k) where
 
 -- | The position in the list is available as the index.
 instance FunctorWithIndex Int [] where
-  imap f = go 0 where
-    go !_ []     = []
-    go !n (x:xs) = f n x : go (n + 1) xs
+  imap = imapListOff 0
   {-# INLINE imap #-}
 instance FoldableWithIndex Int [] where
   ifoldMap = ifoldMapListOff 0
@@ -296,26 +294,44 @@ instance FoldableWithIndex Int [] where
   ifoldr = ifoldrListOff 0
   {-# INLINE ifoldr #-}
   ifoldl' = ifoldl'ListOff 0
+  {-# INLINE ifoldl' #-}
 instance TraversableWithIndex Int [] where
   itraverse = itraverseListOff 0
   {-# INLINE itraverse #-}
 
+imapListOff :: Int -> (Int -> a -> b) -> [a] -> [b]
+imapListOff off f = go off
+  where
+    -- Recursive worker so imapListOff is inlinable.
+    go !_ []     = []
+    go !n (x:xs) = f n x : go (n + 1) xs
+{-# INLINE imapListOff #-}
+
 ifoldMapListOff :: Monoid m => Int -> (Int -> a -> m) -> [a] -> m
-ifoldMapListOff off f = ifoldrListOff off (\i x acc -> mappend (f i x) acc) mempty
+ifoldMapListOff off f =
+  -- Mimic implementation of foldMap from base and use mconcat/map instead of
+  -- foldr/mappend because mconcat doesn't degrade into quadratic performance
+  -- with types such as ByteString or Text.
+  mconcat . imapListOff off f
+{-# INLINE ifoldMapListOff #-}
 
 ifoldrListOff :: Int -> (Int -> a -> b -> b) -> b -> [a] -> b
-ifoldrListOff !_   _ z []     = z
-ifoldrListOff !off f z (x:xs) = f off x (ifoldrListOff (off + 1) f z xs)
+ifoldrListOff off f z = go off
+  where
+    -- Recursive worker so ifoldrListOff is inlinable.
+    go !_ []     = z
+    go !n (x:xs) = f n x (go (n + 1) xs)
+{-# INLINE ifoldrListOff #-}
 
 ifoldl'ListOff :: Int -> (Int -> b -> a -> b) -> b -> [a] -> b
-ifoldl'ListOff !_   _ !z []     = z
-ifoldl'ListOff !off f !z (x:xs) = ifoldl'ListOff (off + 1) f (f off z x) xs
+ifoldl'ListOff off f z0 = \xs -> ifoldrListOff off (\n v fn z -> fn $! f n z v) id xs z0
+{-# INLINE ifoldl'ListOff #-}
 
 -- traverse (uncurry' f) . zip [0..] seems to not work well:
 -- https://gitlab.haskell.org/ghc/ghc/-/issues/22673
 itraverseListOff :: Applicative f => Int -> (Int -> a -> f b) -> [a] -> f [b]
-itraverseListOff !_   _ []     = pure []
-itraverseListOff !off f (x:xs) = liftA2 (:) (f off x) (itraverseListOff (off + 1) f xs)
+itraverseListOff off f = ifoldrListOff off (\n x xs -> liftA2 (:) (f n x) xs) (pure [])
+{-# INLINE itraverseListOff #-}
 
 -- TODO: we could experiment with streaming framework
 -- imapListFB f xs = build (\c n -> ifoldr (\i a -> c (f i a)) n xs)
@@ -336,7 +352,7 @@ instance TraversableWithIndex Int ZipList where
 -------------------------------------------------------------------------------
 
 instance FunctorWithIndex Int NonEmpty where
-  imap = imapDefault
+  imap f ~(a :| as) = f 0 a :| imapListOff 1 f as
   {-# INLINE imap #-}
 instance FoldableWithIndex Int NonEmpty where
   ifoldMap f (x :| xs) = mappend (f 0 x) (ifoldMapListOff 1 f xs)


### PR DESCRIPTION
The way folding functions were written (explicit recursion) prevented GHC from inlining them and exposing them to further optimizations (like specialization). Making them inlinable results in massive performance improvements.

Relevant benchmark results (needs #51 as a baseline) with GHC 9.10.3:

```
$ cabal run traversals -- --baseline traversals.csv
All
  vector
    imap
      native:  OK
        35.3 μs ± 3.3 μs,       same as baseline
      imap:    OK
        35.6 μs ± 2.8 μs,       same as baseline
      default: OK
        91.4 μs ± 4.7 μs, 21% less than baseline
    itraverse: OK
      98.1 μs ± 7.8 μs, 68% less than baseline
...
  list
    imap
      native:  OK
        44.6 μs ± 3.3 μs,       same as baseline
      imap:    OK
        42.0 μs ± 3.5 μs,       same as baseline
      default: OK
        39.0 μs ± 3.8 μs, 33% less than baseline
    itraverse: OK
      60.9 μs ± 1.7 μs, 76% less than baseline
```

```
$ cabal run folds -- --baseline folds.csv
All
  vector
    itoList
      native:          OK
        29.2 μs ± 2.3 μs,       same as baseline
      itoList:         OK
        34.5 μs ± 1.4 μs,       same as baseline
    ifoldMap ([]):     OK
      57.1 μs ± 5.5 μs, 55% less than baseline
    ifoldMap (vector): OK
      16.2 ms ± 1.6 ms, 77% less than baseline
    ifoldMap' (sum):   OK
      9.09 μs ± 688 ns,       same as baseline
    ifoldr:            OK
      34.6 μs ± 1.3 μs,        same as baseline
    ifoldl:            OK
      29.9 μs ± 2.9 μs,       same as baseline
    ifoldr':           OK
      6.70 μs ± 516 ns,       same as baseline
    ifoldl':           OK
      9.17 μs ± 596 ns,       same as baseline
...
  list
    itoList
      native:          OK
        34.7 μs ± 1.3 μs,       same as baseline
      itoList:         OK
        39.1 μs ± 3.7 μs, 15% less than baseline
    ifoldMap ([]):     OK
      73.9 μs ± 6.6 μs, 54% more than baseline
    ifoldMap (vector): OK
      191  μs ±  13 μs, 99% less than baseline
    ifoldMap' (sum):   OK
      10.4 μs ± 944 ns, 64% less than baseline
    ifoldr:            OK
      41.0 μs ± 3.4 μs, 12% less than baseline
    ifoldl:            OK
      200  μs ±  11 μs,       same as baseline
    ifoldr':           OK
      154  μs ±  11 μs,       same as baseline
    ifoldl':           OK
      13.1 μs ± 1.1 μs, 57% less than baseline
```

ifoldMap is slower now when mappend is relatively cheap (on the other hand it was previously unusable with vector/bytestring/text etc.), so I'm not going to fiercely defend change to `ifoldMapListOff`, but I think it's less surprising for it to agree wrt. time complexity with `foldMap` from `base`.

Btw, I noticed this while checking out core for checkIxAdjoin from optics test suite. [This](https://github.com/arybczak/perf-test/blob/6acf7b10693d64eddbc0b24ea6327ca4a1e31da7/src/MyLib.hs#L11) gets almost twice as fast with my change.

Before:

```
$ cabal run perf-test -- --csv perf.csv
All
  test: OK
    35.1 μs ± 2.0 μs
```

Now:

```
$ cabal run perf-test -- --baseline perf.csv
All
  test: OK
    18.5 μs ± 1.4 μs, 47% less than baseline
```
