### PR TITLE
bumping base and containers

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -14,6 +14,7 @@
 #
 name: Haskell-CI
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     container:
       image: buildpack-deps:jammy

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -24,14 +24,18 @@ jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-20.04
-    timeout-minutes:
-      60
+    timeout-minutes: 60
     container:
       image: buildpack-deps:jammy
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.1
+            compilerKind: ghc
+            compilerVersion: 9.14.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.12.1
             compilerKind: ghc
             compilerVersion: 9.12.1
@@ -91,12 +95,12 @@ jobs:
       - name: Install GHCup
         run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.2/x86_64-linux-ghcup-0.1.50.2 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.1.1 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.1.1 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |

--- a/indexed-traversable-instances/indexed-traversable-instances.cabal
+++ b/indexed-traversable-instances/indexed-traversable-instances.cabal
@@ -32,6 +32,7 @@ tested-with:
    || ==9.8.4
    || ==9.10.1
    || ==9.12.1
+   || ==9.14.1
 
 source-repository head
   type:     git
@@ -42,7 +43,7 @@ library
   default-language: Haskell2010
   hs-source-dirs:   src
   build-depends:
-      base                  >=4.12     && <4.22
+      base                  >=4.12     && <4.23
     , indexed-traversable   >=0.1.4    && <0.2
     , OneTuple              >=0.3      && <0.5
     , tagged                >=0.8.6    && <0.9

--- a/indexed-traversable/indexed-traversable.cabal
+++ b/indexed-traversable/indexed-traversable.cabal
@@ -45,6 +45,7 @@ tested-with:
    || ==9.8.4
    || ==9.10.1
    || ==9.12.1
+   || ==9.14.1
 
 source-repository head
   type:     git
@@ -67,8 +68,8 @@ library
 
   build-depends:
       array         >=0.3.0.2 && <0.6
-    , base          >=4.12    && <4.22
-    , containers    >=0.6.0.1 && <0.8
+    , base          >=4.12    && <4.23
+    , containers    >=0.6.0.1 && <0.9
     , transformers  >=0.5.6.0 && <0.7
 
   if !impl(ghc >=9.6)


### PR DESCRIPTION
Hello and first of all - thank you for your work on the repository. It is the core of many haskell projects. Thank you.

I read the `contributing` document and it clearly states that you'd prefer issues over prs for version bumps but I created a pr anyway having noticed this issue: https://github.com/haskellari/indexed-traversable/issues/50 (logged in December 2025). I have a number of other PRs in different repos depending on this library supporting base 4.22 so time is of the essence to me. I'm breaking the `contributing` rules consciously but I'm acting in good faith.

Please let me know if there's anything I can do to help with bumping those dependencies.

---

This PR depends on a similar change: https://github.com/haskellari/qc-instances/pull/112